### PR TITLE
ci: use packaging.version.Version in update_version.py

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -1,4 +1,3 @@
-#  -----------------------------------------------------------------------------
 # Release guide
 
 This document describes release procedures, conventions, and utilities for
@@ -50,7 +49,7 @@ To release a new version:
 
     - Publish the package to PyPI
     - Check out `main`
-    - Update `version.txt` and `pywatershed/version.py` to match the just-released version, with a '+' appended to the version number in `version.txt` to indicate preliminary/development status.
+    - Run `.github/scripts/update_version.py -v x.y+1.0.dev0` to update `version.txt` and `pywatershed/version.py` with the minor version number incremented. The `.dev0` suffix indicates preliminary development status.
     - Draft a PR against `develop` with the updated version files and the updates previously merged to `main`.
 
  5. Merge the PR to `develop`. As above, it is important to *merge* the PR, not squash, to preserve history and keep `develop` and `main` from diverging.
@@ -66,16 +65,18 @@ The former should never need to be run manually. The latter is convenient for fo
 
 ### Updating version numbers
 
-The `update_version.py` script can be used to update version numbers embedded in the repository. The script acquires a file lock to make sure only one process edits version files at a given time.
-
-If the script is run with no arguments, updated timestamp comments are written but the version number is not changed.
-
-A '+' is appended to the version number in `version.txt` (if it was not already there) to indicate that the repository is in a preliminary/development state. To omit the '+' for release-ready versions, use the `--approve` (short `-a`) flag. To set the version number, use the `--version` (short `-v`) option.
+The `update_version.py` script can be used to update version numbers embedded in the repository. The script acquires a file lock to make sure only one process edits version files at a given time. If the script is run with no arguments, updated timestamp comments are written but the version number is not changed. To set the version number, use the `--version` (short `-v`) option.
 
 For instance, to set the version number before a release:
 
 ```shell
 python .github/scripts/update_version.py -a -v 0.1.3
+```
+
+Or to set the version number on `develop` following a release:
+
+```shell
+python .github/scripts/update_version.py -a -v 0.2.0.dev0
 ```
 
 To get the current version number without writing any changes to the repository's files, use the `--get` (short `-g`) flag:

--- a/.github/scripts/update_version.py
+++ b/.github/scripts/update_version.py
@@ -1,104 +1,24 @@
 import argparse
 import textwrap
 from datetime import datetime
-from enum import Enum
-from os import PathLike
 from pathlib import Path
-from typing import NamedTuple
 
+from filelock import FileLock
+from packaging.version import Version
 
 
 _project_name = "pywatershed"
 _project_root_path = Path(__file__).parent.parent.parent
 _version_txt_path = _project_root_path / "version.txt"
 _version_py_path = _project_root_path / _project_name / "version.py"
+_initial_version = Version("0.0.1")
+_current_version = Version(_version_txt_path.read_text().strip())
 
 
-class Version(NamedTuple):
-    """Semantic version number"""
-
-    major: int = 0
-    minor: int = 0
-    patch: int = 0
-
-    def __repr__(self):
-        return f"{self.major}.{self.minor}.{self.patch}"
-
-    @classmethod
-    def from_string(cls, version: str) -> "Version":
-        t = version.split(".")
-
-        vmajor = int(t[0])
-        vminor = int(t[1])
-        vpatch = int(t[2])
-
-        return cls(major=vmajor, minor=vminor, patch=vpatch)
-
-    @classmethod
-    def from_py_file(cls, path: PathLike) -> "Version":
-        """Parse version information from a version.py file"""
-
-        lines = [
-            line.rstrip("\n")
-            for line in open(Path(path).expanduser().absolute(), "r")
-        ]
-        vmajor = vminor = vpatch = None
-        for line in lines:
-            line = line.strip()
-            if not any(line):
-                continue
-
-            def get_ver(l):
-                return l.split("=")[1]
-
-            if "__version__" not in line:
-                if "major" in line:
-                    vmajor = int(get_ver(line))
-                elif "minor" in line:
-                    vminor = int(get_ver(line))
-                elif "patch" in line or "micro" in line:
-                    vpatch = int(get_ver(line))
-
-        assert (
-            vmajor is not None and vminor is not None and vpatch is not None
-        ), "version string must follow semantic version format: major.minor.patch"
-        return cls(major=vmajor, minor=vminor, patch=vpatch)
-    
-    @classmethod
-    def from_txt_file(cls, path: PathLike) -> "Version":
-        """Parse version information from a version.txt file"""
-
-        lines = [
-            line.rstrip("\n")
-            for line in open(Path(path).expanduser().absolute())
-        ]
-        vmajor = vminor = vpatch = None
-        for line in lines:
-            line = line.strip()
-            if not any(line):
-                continue
-            t = line.split(".")
-            vmajor = int(t[0])
-            vminor = int(t[1])
-            vpatch = int(t[2].replace("+", ""))
-
-        assert (
-            vmajor is not None and vminor is not None and vpatch is not None
-        ), "version string must follow semantic version format: major.minor.patch"
-        return cls(major=vmajor, minor=vminor, patch=vpatch)
-
-
-_initial_version = Version(0, 0, 1)
-_current_version = Version.from_txt_file(_version_txt_path)
-
-
-def update_version_txt(version: Version, approve: bool = False):
+def update_version_txt(version: Version):
     with open(_version_txt_path, "w") as f:
-        ver_str = str(version)
-        if not approve:
-            ver_str += "+"
-        f.write(str(ver_str))
-    print(f"Updated {_version_txt_path} to version {ver_str}")
+        f.write(str(version))
+    print(f"Updated {_version_txt_path} to version {version}")
 
 
 def update_version_py(timestamp: datetime, version: Version):
@@ -107,32 +27,27 @@ def update_version_py(timestamp: datetime, version: Version):
             f"# {_project_name} version file automatically created using "
             f"{Path(__file__).name} on {timestamp:%B %d, %Y %H:%M:%S}\n\n"
         )
-        f.write(f"major = {version.major}\n")
-        f.write(f"minor = {version.minor}\n")
-        f.write(f"micro = {version.patch}\n")
-        f.write("__version__ = f'{major}.{minor}.{micro}'\n")
+        f.write(f'__version__ = "{version}"\n')
+        f.close()
     print(f"Updated {_version_py_path} to version {version}")
 
 
 def update_version(
     timestamp: datetime = datetime.now(),
     version: Version = None,
-    approve: bool = False,
 ):
-    from filelock import FileLock   
-
-    lock_path = Path(_version_py_path.name + ".lock")
+    lock_path = Path(_version_txt_path.name + ".lock")
     try:
         lock = FileLock(lock_path)
-        previous = Version.from_txt_file(_version_txt_path)
+        previous = Version(_version_txt_path.read_text().strip())
         version = (
             version
             if version
-            else Version(previous.major, previous.minor, previous.patch)
+            else Version(previous.major, previous.minor, previous.micro)
         )
 
         with lock:
-            update_version_txt(version, approve)
+            update_version_txt(version)
             update_version_py(timestamp, version)
     finally:
         try:
@@ -147,9 +62,11 @@ if __name__ == "__main__":
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=textwrap.dedent(
             """\
-            Update version information stored in version.py. If --version is not
-            provided, the version number will not be changed. The number should
-            follow the semantic versioning convention '<major>.<minor>.<patch>'.
+            Update version information stored in version.txt in the project root,
+            as well as several other files in the repository. If --version is not
+            provided, the version number will not be changed. A file lock is held
+            to synchronize file access. The version tag must comply with standard
+            '<major>.<minor>.<patch>' format conventions for semantic versioning.
             """
         ),
     )
@@ -158,13 +75,6 @@ if __name__ == "__main__":
         "--version",
         required=False,
         help="Specify the release version",
-    )
-    parser.add_argument(
-        "-a",
-        "--approve",
-        required=False,
-        action="store_true",
-        help="Indicate release is approved (defaults to false for development status)",
     )
     parser.add_argument(
         "-g",
@@ -176,12 +86,14 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.get:
-        print(_current_version)
+        print(
+            Version((_project_root_path / "version.txt").read_text().strip())
+        )
     else:
         update_version(
             timestamp=datetime.now(),
-            version=Version.from_string(args.version)
+            version=Version(args.version)
             if args.version
             else _current_version,
-            approve=args.approve,
+            approved=args.approve,
         )


### PR DESCRIPTION
Modify `update_version.py` to use Python's [builtin `Version` utility](https://packaging.pypa.io/en/stable/version.html#usage)