### PR TITLE
Fix release ci

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -195,7 +195,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          version=$(python .github/scripts/update_version.py -g)
+          version=$(cat version.txt | xargs)
           title="pywatershed $version"
           notes=$(cat "changelog/CHANGELOG_$version.md" | grep -v "### Version $version")
           gh release create "$version" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,7 +90,7 @@ jobs:
         run: |
           ref="${{ github.ref_name }}"
           version="${ref#"v"}"
-          python .github/scripts/update_version.py -v "$version" -a
+          python .github/scripts/update_version.py -v "$version"
           python .github/scripts/pull_request_prepare.py
           python -c "import pywatershed; print('Version: ', pywatershed.__version__)"
           echo "version=$version" >> $GITHUB_OUTPUT


### PR DESCRIPTION
- remove `-a` flag when invoking `update_version.py`
- just `cat version.txt` when drafting release post, don't use `update_version.py -g` (needs filelock)