### PR TITLE
refactor test data generation

### DIFF
--- a/environment_w_jupyter.yml
+++ b/environment_w_jupyter.yml
@@ -48,6 +48,7 @@ dependencies:
       - black
       - click != 8.1.0
       - isort
+      - filelock
       - flake8
       - git+https://github.com/modflowpy/flopy.git
       - jupyter_black

--- a/test_data/README.md
+++ b/test_data/README.md
@@ -1,9 +1,8 @@
-# test_data/
+# Test data
 
-This directory contains
+The `test_data` directory contains
   * domain directories for domain tests
-  * scripts/ which document how domain tests are established.
-
+  * `scripts/`, which contains scripts to run domain simulations and generate data.
 
 ## Domain directories
 
@@ -15,15 +14,18 @@ output to a disk faster than the one where the repository lives. However, we do 
 version control certain files in the directory. See the `conus_2yr/README.md` for details 
 on how it is setup.
 
-
 Other domain directories can be run from pytest given the repository. The pytest 
 flag `--all_domains` will detect these repos and run them.
 
-
-
-# scripts/
-
-This contains code for reproducing test data in the domains. Importantly, `run_domains.py` should be run
-occasionally to update the test data.
-
 Original source data can be found on Denali for most (all?) domains in `/home/jmccreight/pywatershed_data`.
+
+# Generating data
+
+The `test_data/scripts` subdirectory contains code for reproducing test data in the domains. Importantly, `test_run_domains.py` should be run occasionally to update the test data.  After running the domains, NetCDF files can be created from simulation outputs by running the tests in `test_nc_domains.py`. E.g.,
+
+```shell
+pytest -v -n auto test_run_domains.py
+pytest -v -n auto test_nc_domains.py
+```
+
+NetCDF dependencies are encoded implicitly into the `pytest` fixture system: `test_nc_domains.py` uses a custom test parametrization with `pytest_generate_tests` to map each CSV file created by the domain simulation to one or more NetCDF files, which are then aggregated into further files on session teardown by [yield fixtures](https://docs.pytest.org/en/7.2.x/how-to/fixtures.html#teardown-cleanup-aka-fixture-finalization). A [filelock](https://pytest-xdist.readthedocs.io/en/latest/how-to.html#making-session-scoped-fixtures-execute-only-once) is used to ensure aggregate files are only created once, even with multiple `pytest-xdist` workers.

--- a/test_data/scripts/conftest.py
+++ b/test_data/scripts/conftest.py
@@ -3,8 +3,12 @@ import pathlib as pl
 import sys
 from fnmatch import fnmatch
 from platform import processor
+from typing import List
+import numpy as np
 
 import pytest
+
+from pywatershed import CsvFile, Soltab
 
 
 def pytest_addoption(parser):
@@ -55,32 +59,6 @@ test_dirs = sorted(
 # This would change to handle other/additional schedulers
 domain_globs_schedule = ["*conus*"]
 
-# For generating timeseries of previous states
-previous_vars = [
-    "dprst_stor_hru",
-    "freeh2o",
-    "hru_impervstor",
-    "pk_ice",
-    "pref_flow_stor",
-    "slow_stor",
-    "soil_lower",
-    "soil_moist",
-    "soil_rechr",
-    "ssres_stor",
-]
-
-misc_nc_file_vars = [
-    "infil",
-    "sroff",
-    "ssres_flow",
-    "gwres_flow",
-]
-
-
-final_nc_file_vars = [
-    "through_rain",
-]
-
 
 def scheduler_active():
     slurm = os.getenv("SLURM_JOB_ID") is not None
@@ -102,26 +80,27 @@ def enforce_scheduler(test_dir):
     return None
 
 
-def collect_simulations(domain_list: list, force: bool):
+def collect_simulations(domain_list: list, force: bool = True, verbose: bool = False):
     simulations = {}
     for test_dir in test_dirs:
-        for pth in test_dir.iterdir():
-            # checking for prcp.cbh ensure this is a self-contained run (all
-            # files in repo)
-            if (
-                (test_dir / "prcp.cbh").exists()
-                and pth.is_file()
-                and pth.name == "control.test"
-            ):
-                if len(domain_list) and (test_dir.name not in domain_list):
-                    continue
+        # ensure this is a self-contained run (all files in repo)
+        if not (test_dir / "prcp.cbh").exists():
+            continue
+    
+        # filter selected domains
+        if len(domain_list) and (test_dir.name not in domain_list):
+            continue
 
-                if not force:
-                    enforce_scheduler(test_dir)
+        # optionally enforce scheduler
+        if not force:
+            enforce_scheduler(test_dir)
 
-                # add simulation
-                simulations[str(test_dir)] = pth.name
+        # if control file is found, add simulation
+        ctrl_file = next(iter([p for p in test_dir.iterdir() if p.is_file() and p.name == "control.test"]), None)
+        if ctrl_file:
+            simulations[str(test_dir)] = ctrl_file.name
 
+    # make sure all requested domains were found
     if len(domain_list) and (len(simulations) < len(domain_list)):
         requested = set(domain_list)
         found = [pl.Path(dd).name for dd in simulations.keys()]
@@ -132,13 +111,14 @@ def collect_simulations(domain_list: list, force: bool):
         )
         pytest.exit(msg)
 
-    print("\nrun_domains.py found the following domains to run:\n")
-    print(f"{list(simulations.keys())}")
+    if verbose:
+        print("\nrun_domains.py found the following domains to run:\n")
+        print(f"{list(simulations.keys())}")
+
     return simulations
 
 
-def collect_csv_files(domain_list: list, force: bool):
-    simulations = collect_simulations(domain_list, force)
+def collect_csv_files(simulations: list) -> List[pl.Path]:
     csv_files = []
     for key, value in simulations.items():
         output_pth = pl.Path(key) / "output"
@@ -147,63 +127,38 @@ def collect_csv_files(domain_list: list, force: bool):
     return csv_files
 
 
-def collect_misc_nc_files(domain_list: list, var_list: list, force: bool):
-    simulations = collect_simulations(domain_list, force)
+def collect_nc_files(simulations: list, var_list: list):
     sim_dirs = list(simulations.keys())
-    misc_nc_files = []
+    nc_files = []
     for var in var_list:
         for sim in sim_dirs:
-            the_file = pl.Path(sim) / f"output/{var}.nc"
-            # assert the_file.exists()
-            misc_nc_files += [the_file.with_suffix("")]
-
-    return misc_nc_files
+            nc_files += [(pl.Path(sim) / f"output/{var}.nc")]
+    return nc_files
 
 
 def pytest_generate_tests(metafunc):
     domain_list = metafunc.config.getoption("domain")
     force = metafunc.config.getoption("force")
+    simulations = collect_simulations(domain_list, force)
+    csv_files = collect_csv_files(simulations)
 
-    if "simulations" in metafunc.fixturenames:
-        simulations = collect_simulations(domain_list, force)
-        sim_list = [
-            {"ws": key, "control_file": val}
-            for key, val in simulations.items()
+    key = "simulation"
+    if key in metafunc.fixturenames:
+        sims = [
+            {"ws": key, "control_file": val} for key, val in simulations.items()
         ]
-        ids = [pl.Path(ss).name for ss in simulations.keys()]
-        metafunc.parametrize("simulations", sim_list, ids=ids)
+        ids = [pl.Path(k).name for k in simulations.keys()]
+        metafunc.parametrize(key, sims, ids=ids, scope="session")
 
-    if "csv_files" in metafunc.fixturenames:
-        csv_files = collect_csv_files(domain_list, force)
-        ids = [ff.parent.parent.name + ":" + ff.name for ff in csv_files]
-        metafunc.parametrize("csv_files", csv_files, ids=ids)
+    key = "soltab_file"
+    if key in metafunc.fixturenames:
+        soltab_files = [pl.Path(k) / "soltab_debug" for k in simulations.keys()]
+        ids = [f.parent.name + ":" + f.name for f in soltab_files]
+        metafunc.parametrize(key, soltab_files, ids=ids, scope="session")
 
-    if "csv_files_prev" in metafunc.fixturenames:
-        csv_files = collect_csv_files(domain_list, force)
-        csv_files = [
-            ff for ff in csv_files if ff.with_suffix("").name in previous_vars
-        ]
-        ids = [ff.parent.parent.name + ":" + ff.name for ff in csv_files]
-        metafunc.parametrize("csv_files_prev", csv_files, ids=ids)
+    key = "csv_file"
+    if key in metafunc.fixturenames:
+        ids = [f.parent.name + ":" + f.name for f in csv_files]
+        metafunc.parametrize(key, csv_files, ids=ids)
 
-    if "misc_nc_files_input" in metafunc.fixturenames:
-        misc_nc_files = collect_misc_nc_files(
-            domain_list, misc_nc_file_vars, force
-        )
-        ids = [ff.parent.parent.name + ":" + ff.name for ff in misc_nc_files]
-        metafunc.parametrize("misc_nc_files_input", misc_nc_files, ids=ids)
-
-    if "misc_nc_final_input" in metafunc.fixturenames:
-        misc_nc_files = collect_misc_nc_files(
-            domain_list, final_nc_file_vars, force
-        )
-        ids = [ff.parent.parent.name + ":" + ff.name for ff in misc_nc_files]
-        metafunc.parametrize("misc_nc_final_input", misc_nc_files, ids=ids)
-
-    if "soltab_file" in metafunc.fixturenames:
-        simulations = collect_simulations(domain_list, force)
-        soltab_files = [
-            pl.Path(kk) / "soltab_debug" for kk in simulations.keys()
-        ]
-        ids = [ff.parent.name + ":" + ff.name for ff in soltab_files]
-        metafunc.parametrize("soltab_file", soltab_files, ids=ids)
+    

--- a/test_data/scripts/conftest.py
+++ b/test_data/scripts/conftest.py
@@ -142,7 +142,7 @@ def pytest_generate_tests(metafunc):
     csv_files = collect_csv_files(simulations)
 
     if "csv_file" in metafunc.fixturenames:
-        ids = [ff.parent.name + ":" + ff.name for ff in csv_files]
+        ids = [ff.parent.parent.name + ":" + ff.name for ff in csv_files]
         metafunc.parametrize("csv_file", csv_files, ids=ids)
 
     if "soltab_file" in metafunc.fixturenames:

--- a/test_data/scripts/pytest.ini
+++ b/test_data/scripts/pytest.ini
@@ -1,2 +1,8 @@
 [pytest]
 addopts = --order-dependencies
+python_files =
+    test_*.py
+python_functions =
+    create_*
+    make_*
+    test_*

--- a/test_data/scripts/test_nc_domains.py
+++ b/test_data/scripts/test_nc_domains.py
@@ -92,7 +92,7 @@ def soltab_netcdf_file(tmp_path_factory, soltab_file) -> Path:
     nc_paths = []
 
     with FileLock(root_tmpdir / "soltab_nc.lock"):
-        yield soltab_file  # wait til session cleanup
+        yield  # postpone the work until session cleanup
 
         # this is a hack that should probably rely on the yaml if/when this
         # fails
@@ -126,7 +126,7 @@ def final_netcdf_file(tmp_path_factory, simulation) -> Path:
     nc_path = data_dir / "through_rain.nc"
 
     with FileLock(root_tmpdir / "final_nc.lock"):
-        yield nc_path  # wait til session cleanup
+        yield  # do this in session cleanup
 
         if nc_path.is_file():
             return

--- a/test_data/scripts/test_nc_domains.py
+++ b/test_data/scripts/test_nc_domains.py
@@ -1,89 +1,113 @@
-from time import sleep
+from pathlib import Path
+from filelock import FileLock
 
 import numpy as np
+
+from pywatershed import CsvFile, Soltab
+from pywatershed.parameters import PrmsParameters
+from pywatershed.constants import epsilon64, zero
+
 import pytest
 import xarray as xr
 
-from pywatershed import CsvFile, Soltab
-from pywatershed.constants import epsilon64, zero
-from pywatershed.parameters import PrmsParameters
+
+# For generating timeseries of previous states
+previous_vars = [
+    "dprst_stor_hru",
+    "freeh2o",
+    "hru_impervstor",
+    "pk_ice",
+    "pref_flow_stor",
+    "slow_stor",
+    "soil_lower",
+    "soil_moist",
+    "soil_rechr",
+    "ssres_stor",
+]
+
+misc_nc_file_vars = [
+    "infil",
+    "sroff",
+    "ssres_flow",
+    "gwres_flow",
+]
 
 
-def test_csv_to_netcdf(csv_files):
-    nc_path = csv_files.with_suffix(".nc")
-    CsvFile(csv_files).to_netcdf(nc_path)
+final_nc_file_vars = [
+    "through_rain",
+]
+
+
+@pytest.fixture
+def netcdf_file(csv_file) -> Path:
+    """Convert CSV files from model output to NetCDF"""
+
+    nc_path = csv_file.with_suffix(".nc")
+    data_dir = csv_file.parent
+    domain_dir = data_dir.parent
+    CsvFile(csv_file).to_netcdf(nc_path)
     assert nc_path.exists()
 
+    if csv_file.stem in previous_vars:
+        nc_name = csv_file.stem + "_prev.nc"
+        nc_path = data_dir / nc_name
+        csv = CsvFile({nc_path.stem: csv_file})
+        csv._get_data()  # why so private?
+        orig_dates = csv._data["date"].copy()
+        csv._data = np.roll(csv._data, 1, axis=0)
+        csv._data["date"] = orig_dates
+        # Here we will eventually want to supply the desired initial conditions
+        for hh in range(len(csv._data[0])):
+            if hh == 0:
+                continue
+            csv._data[0][hh] = np.zeros([1])[0]
+        csv.to_netcdf(nc_path)
+        assert nc_path.exists()
 
-def test_soltab_to_netcdf(soltab_file):
-    # the nhm_ids are not available in the solta_debug file currently, so get
-    # them from the domain parameters
-    domain_dir = soltab_file.parent
-    # this is a hack that should probably rely on the yaml if/when this fails
-    params = PrmsParameters.load(domain_dir / "myparam.param")
-    nhm_ids = params.parameters["nhm_id"]
-
-    output_dir = domain_dir / "output"
-    soltab = Soltab(soltab_file, output_dir=output_dir, nhm_ids=nhm_ids)
-
-    for var in soltab.variables:
-        assert (output_dir / f"{var}.nc").exists()
-
-
-@pytest.mark.order(after=["test_csv_to_netcdf"])
-def test_csv_to_previous_netcdf(csv_files_prev):
-    nc_name = csv_files_prev.with_suffix("").name + "_prev.nc"
-    nc_path = csv_files_prev.parent / nc_name
-    csv = CsvFile({nc_path.stem: csv_files_prev})
-    csv._get_data()  # why so private?
-    orig_dates = csv._data["date"].copy()
-    csv._data = np.roll(csv._data, 1, axis=0)
-    csv._data["date"] = orig_dates
-    # Here we will eventually want to supply the desired initial conditions
-    for hh in range(len(csv._data[0])):
-        if hh == 0:
-            continue
-        csv._data[0][hh] = np.zeros([1])[0]
-    csv.to_netcdf(nc_path)
-    assert nc_path.exists()
-
-
-@pytest.mark.order(after=["test_csv_to_previous_netcdf"])
-def test_misc_netcdf(misc_nc_files_input):
-    if misc_nc_files_input.name in ["sroff", "ssres_flow", "gwres_flow"]:
-        data_dir = misc_nc_files_input.parent
-        domain_dir = misc_nc_files_input.parent.parent
+    if nc_path.stem in ["sroff", "ssres_flow", "gwres_flow"]:
         params = PrmsParameters.load(domain_dir / "myparam.param")
-        var = misc_nc_files_input.name
+        var = nc_path.stem
         ds = xr.open_dataset(data_dir / f"{var}.nc")
         ds = ds.rename({var: f"{var}_vol"})
-        ds = ds * params.data_vars["hru_in_to_cf"]
+        ds = ds * params.metadata["hru_in_to_cf"]
         ds.to_netcdf(data_dir / f"{var}_vol.nc")
         ds.close()
 
-    if misc_nc_files_input.name == "infil":
-        domain_dir = misc_nc_files_input.parent.parent
+    if nc_path.stem == "infil":
         params = PrmsParameters.load(domain_dir / "myparam.param").parameters
         imperv_frac = params["hru_percent_imperv"]
         dprst_frac = params["dprst_frac"]
         perv_frac = 1.0 - imperv_frac - dprst_frac
-        ds = xr.open_dataset(misc_nc_files_input.with_suffix(".nc"))
+        ds = xr.open_dataset(nc_path.with_suffix(".nc"))
         ds = ds.rename(infil="infil_hru")
-
         # not necessary
         # perv_frac = np.tile(perv_frac, (ds["infil_hru"].shape[0], 1))
         ds["infil_hru"] = ds["infil_hru"] * perv_frac
-
-        ds.to_netcdf(misc_nc_files_input.parent / "infil_hru.nc")
+        ds.to_netcdf(data_dir / "infil_hru.nc")
         ds.close()
 
-    assert True
+    return nc_path
 
 
-@pytest.mark.order(after=["test_misc_netcdf", "test_csv_to_previous_netcdf"])
-def test_misc_final(misc_nc_final_input):
-    if misc_nc_final_input.name == "through_rain":
-        data_dir = misc_nc_final_input.parent
+def make_netcdf_files(netcdf_file):
+    print(f"Created NetCDF from CSV: {netcdf_file}")
+
+
+@pytest.fixture(scope="session")
+def final_netcdf_file(tmp_path_factory, simulation) -> Path:
+    """Create the final NetCDF file (through_rain.nc) from other NetCDFs"""
+
+    root_tmpdir = tmp_path_factory.getbasetemp().parent
+    data_dir = Path(simulation["ws"]) / "output"
+    data_dir.mkdir(exist_ok=True)
+    nc_path = data_dir / "through_rain.nc"
+
+    with FileLock(root_tmpdir / "final_nc.lock"):
+        yield nc_path  # wait til session cleanup
+
+        if nc_path.is_file():
+            return
+
         data_vars = [
             "net_rain",
             "pk_ice_prev",
@@ -95,38 +119,57 @@ def test_misc_final(misc_nc_final_input):
         data = {}
         for vv in data_vars:
             data_file = data_dir / f"{vv}.nc"
-
-            if False:
-                result = xr.open_dataset(data_file)[vv]
-            else:
-                # None of this case should be necessary if the test
-                # really runs after the other tests as specified
-                # But the following will apparently trigger the race conditions
-                # rm ../*/output/*.nc; pytest -vv -n=auto test_nc_domains.py
-                result = None
-                while result is None:
-                    try:
-                        result = xr.open_dataset(data_file)[vv]
-                    except FileNotFoundError:
-                        sleep(0.1)
-                        pass
-                    except OSError:
-                        sleep(0.1)
-                        pass
-
+            result = xr.open_dataset(data_file)[vv]
             data[vv] = result
 
-        wh_through = (
-            ((data["pk_ice_prev"] + data["freeh2o_prev"]) <= epsilon64)
-            & ~(data["newsnow"] == 1)
-        ) | (data["pptmix_nopack"] == 1)
+        try:
+            wh_through = (
+                ((data["pk_ice_prev"] + data["freeh2o_prev"]) <= epsilon64)
+                & ~(data["newsnow"] == 1)
+            ) | (data["pptmix_nopack"] == 1)
 
-        through_rain = data["net_rain"].copy()
-        through_rain[:] = np.where(wh_through, data["net_rain"], zero)
+            through_rain = data["net_rain"].copy()
+            through_rain[:] = np.where(wh_through, data["net_rain"], zero)
+            through_rain.to_dataset(name="through_rain").to_netcdf(nc_path)
+            through_rain.close()
+            assert nc_path.exists()
+        finally:
+            for vv in data_vars:
+                data[vv].close()
 
-        through_rain.to_dataset(name="through_rain").to_netcdf(
-            misc_nc_final_input.parent / "through_rain.nc"
-        )
-        through_rain.close()
-        for vv in data_vars:
-            data[vv].close()
+@pytest.fixture(scope="session")
+def soltab_netcdf_file(tmp_path_factory, soltab_file) -> Path:
+    """Convert soltab files to NetCDF, one file for each variable"""
+
+    # the nhm_ids are not available in the solta_debug file currently, so get
+    # them from the domain parameters
+    domain_dir = soltab_file.parent
+    output_dir = domain_dir / "output"
+    output_dir.mkdir(exist_ok=True)
+    root_tmpdir = tmp_path_factory.getbasetemp().parent
+    nc_paths = []
+
+    with FileLock(root_tmpdir / "soltab_nc.lock"):
+        yield soltab_file  # wait til session cleanup
+
+        # this is a hack that should probably rely on the yaml if/when this fails
+        params = PrmsParameters.load(domain_dir / "myparam.param")
+        nhm_ids = params.parameters["nhm_id"]
+        soltab = Soltab(soltab_file, nhm_ids=nhm_ids)
+
+        already_created = (output_dir / "soltab_potsw.nc").is_file()
+        if not already_created:
+            soltab.to_netcdf(output_dir=output_dir)
+            print(f"Created NetCDF files from soltab file {soltab_file}:")
+
+        for var in soltab.variables:
+            nc_path = output_dir / f"{var}.nc" 
+            nc_paths.append(nc_path)
+            assert nc_path.exists()
+            print(f"\t{nc_path}")
+
+def make_soltab_netcdf_files(soltab_netcdf_file):
+    print(f"Creating NetCDF files for soltab file {soltab_netcdf_file}")
+
+def make_final_netcdf_files(final_netcdf_file):
+    print(f"Creating final NetCDF file {final_netcdf_file}")

--- a/test_data/scripts/test_run_domains.py
+++ b/test_data/scripts/test_run_domains.py
@@ -13,9 +13,9 @@ def test_exe_available(exe):
     assert os.access(exe, os.X_OK)
 
 
-def test_prms_run(simulations, exe):
-    ws = simulations["ws"]
-    control_file = simulations["control_file"]
+def test_run_prms(simulation, exe):
+    ws = simulation["ws"]
+    control_file = simulation["control_file"]
     print(f"\n\n\n{'*' * 70}\n{'*' * 70}")
     print(
         f"run_domains.py: Running '{control_file}' in {ws}\n\n",


### PR DESCRIPTION
Use session-scoped pytest [yield fixtures](https://docs.pytest.org/en/latest/how-to/fixtures.html#yield-fixtures-recommended), custom [parametrization](https://docs.pytest.org/en/6.2.x/parametrize.html#basic-pytest-generate-tests-example), and [filelock](https://pypi.org/project/filelock/) to generate files in the proper order, serially or in parallel via pytest-xdist.

The basic problem this solves is: can we use pytest to generate files, where some files depend on other files being created first, while parallelizing non-dependent file creation as much as possible?

#### How it works

Use `pytest_generate_tests` to enumerate "source" data files. Define fixtures, parametrized with the source data files, to convert to intermediate data files (kind of like rules in GNU make). Define test functions which consume the fixtures and make intermediate files. Define session-scoped yield fixtures to generate final data files, *but only after yielding* (at which point intermediate files already exist). Use [filelock as suggested in pytest-xdist docs](https://pytest-xdist.readthedocs.io/en/latest/how-to.html#making-session-scoped-fixtures-execute-only-once) to protect the critical section (containing the yield statement and code to generate the final file) in the session-scoped fixtures. Define test functions consuming the session-scoped fixtures. We're done!

All the real work is done in test fixtures. Test functions are only used to trigger the fixtures. Test functions can be thought of like the top-level rule defining a makefile's targets.

If we didn't need to support xdist/parallel, yield fixtures would suffice. The filelock just makes sure only one worker process creates the final file(s).