### PR TITLE
ci: swap setup-fortran for install-gfortran-action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,7 +147,7 @@ jobs:
           if [[ "$MF6_REMOTE" != "$req_remote" ]]; then exit 1; fi
 
       - name: Setup gfortran
-        uses: awvwgk/setup-fortran@main
+        uses: awvwgk/setup-fortran@v1
         with:
           compiler: gcc
           version: 11
@@ -193,8 +193,6 @@ jobs:
           pytest -vv -n=2 --durations=0 run_prms_domains.py --domain=hru_1
           pytest -vv -n=auto --durations=0 convert_prms_output_to_nc.py  --domain=hru_1
           pytest -vv -n=auto --durations=0 remove_prms_csvs.py
-
-
 
       - name: hru_1 - list netcdf input files
         working-directory: test_data

--- a/.github/workflows/ci_examples.yaml
+++ b/.github/workflows/ci_examples.yaml
@@ -31,8 +31,11 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2.4.0
 
-      - name: Install gfortran
-        uses: modflowpy/install-gfortran-action@v1
+      - name: Setup gfortran
+        uses: awvwgk/setup-fortran@v1
+        with:
+          compiler: gcc
+          version: 11
 
       - name: Download GIS files
         working-directory: examples


### PR DESCRIPTION
* `modflowpy/install-gfortran-action` will be retired soon
* use `v1` instead of `main` for `fortran-lang/setup-fortran` 