### PR TITLE
change pytest tmp_path retention policy in autotest via pytest.ini

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,24 +119,25 @@ jobs:
       matrix:
         os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
         python-version: ["3.9", "3.10"]
+
     steps:
 
-    - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
-      with:
-        # this might remove tools that are actually needed,
-        # if set to "true" but frees about 6 GB
-        tool-cache: false
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
 
-        # all of these default to true, but feel free to set to
-        # "false" if necessary for your workflow
-        android: true
-        dotnet: true
-        haskell: true
-        large-packages: true
-        docker-images: true
-        swap-storage: true
-      
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Checkout repo
         uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,6 +123,7 @@ jobs:
     steps:
 
       - name: Free Disk Space (Ubuntu)
+        if: runner.os == 'Linux'
         uses: jlumbroso/free-disk-space@main
         with:
           # this might remove tools that are actually needed,

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,26 +19,6 @@ on:
 
 jobs:
 
-  free-disk-space:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
-      with:
-        # this might remove tools that are actually needed,
-        # if set to "true" but frees about 6 GB
-        tool-cache: false
-
-        # all of these default to true, but feel free to set to
-        # "false" if necessary for your workflow
-        android: true
-        dotnet: true
-        haskell: true
-        large-packages: true
-        docker-images: true
-        swap-storage: true
-
   pyws_setup:
     name: standard installation
     runs-on: ubuntu-latest
@@ -141,6 +121,22 @@ jobs:
         python-version: ["3.9", "3.10"]
     steps:
 
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        # this might remove tools that are actually needed,
+        # if set to "true" but frees about 6 GB
+        tool-cache: false
+
+        # all of these default to true, but feel free to set to
+        # "false" if necessary for your workflow
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: true
+        swap-storage: true
+      
       - name: Checkout repo
         uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,26 @@ on:
 
 jobs:
 
+  free-disk-space:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        # this might remove tools that are actually needed,
+        # if set to "true" but frees about 6 GB
+        tool-cache: false
+
+        # all of these default to true, but feel free to set to
+        # "false" if necessary for your workflow
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: true
+        swap-storage: true
+
   pyws_setup:
     name: standard installation
     runs-on: ubuntu-latest
@@ -227,7 +247,7 @@ jobs:
         working-directory: test_data
         run: |
           find drb_2yr/output_no_dprst/ -name '*.nc'
-          
+
       - name: drb_2yr_nhm - pywatershed tests
         working-directory: autotest
         run: pytest

--- a/autotest/pytest.ini
+++ b/autotest/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-tmp_path_retention_policy=none

--- a/autotest/pytest.ini
+++ b/autotest/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+tmp_path_retention_policy=none


### PR DESCRIPTION
The ubuntu runners were failing because they were running out of storage. Adopting a GH action that frees up 27GiB in ubuntu.