### PR TITLE
deprecated MMRToMF6 as MMR in MF6 is deprecated

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,16 +153,16 @@ jobs:
           echo 'SETUPTOOLS_ENABLE_FEATURES="legacy-editable"' >> $GITHUB_ENV
           cat .mf6_ci_ref_remote  >> $GITHUB_ENV
 
-      - name: Enforce MF6 ref and remote merge to main
-        if: github.base_ref == 'main'
-        run: |
-          echo Merge commit: GITHUB_BASE_REF = $GITHUB_BASE_REF
-          req_ref=swf_q_mmr_and_mct  # if not develop, submit an issue
-          echo $MF6_REF
-          if [[ "$MF6_REF" != "$req_ref" ]]; then exit 1; fi
-          req_remote=MODFLOW-USGS/modflow6
-          echo $MF6_REMOTE
-          if [[ "$MF6_REMOTE" != "$req_remote" ]]; then echo "bad mf6 remote in .mf6_ci_ref_remote"; exit 1; fi
+      # - name: Enforce MF6 ref and remote merge to main
+      #   if: github.base_ref == 'main'
+      #   run: |
+      #     echo Merge commit: GITHUB_BASE_REF = $GITHUB_BASE_REF
+      #     req_ref=swf_q_mmr_and_mct  # if not develop, submit an issue
+      #     echo $MF6_REF
+      #     if [[ "$MF6_REF" != "$req_ref" ]]; then exit 1; fi
+      #     req_remote=MODFLOW-USGS/modflow6
+      #     echo $MF6_REMOTE
+      #     if [[ "$MF6_REMOTE" != "$req_remote" ]]; then echo "bad mf6 remote in .mf6_ci_ref_remote"; exit 1; fi
 
       - name: Setup gfortran
         uses: fortran-lang/setup-fortran@v1
@@ -184,17 +184,17 @@ jobs:
             python=${{matrix.python-version}}
             conda
 
-      - name: Checkout MODFLOW 6
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ env.MF6_REMOTE }}
-          ref: ${{ env.MF6_REF }}
-          path: modflow6
+      # - name: Checkout MODFLOW 6
+      #   uses: actions/checkout@v4
+      #   with:
+      #     repository: ${{ env.MF6_REMOTE }}
+      #     ref: ${{ env.MF6_REF }}
+      #     path: modflow6
 
-      - name: Update flopy MODFLOW 6 classes
-        working-directory: modflow6/autotest
-        run: |
-          python update_flopy.py
+      # - name: Update flopy MODFLOW 6 classes
+      #   working-directory: modflow6/autotest
+      #   run: |
+      #     python update_flopy.py
 
       - name: Install pywatershed
         run: |

--- a/autotest/test_prms_to_mf6.py
+++ b/autotest/test_prms_to_mf6.py
@@ -24,6 +24,7 @@ def lateral_flow_ans_ds(simulation):
 @pytest.mark.parametrize("bc_binary_files", [True, False])
 @pytest.mark.parametrize("bc_flows_combine", [True, False])
 def test_mmr_to_mf6(simulation, tmp_path, bc_binary_files, bc_flows_combine):
+    pytest.skip("MF6 MMR is deprecated and MMRToMF6 testing is deprecated")
     units = pint.UnitRegistry()
     ans = lateral_flow_ans_ds(simulation)
     times = ans.time.values


### PR DESCRIPTION
MMR functionality on an MF6 branch is stale and may be abandoned. Flopy can not be used to generate codes exporting PRMS data for use in MF6 MMR anymore. We are keeping the code but no longer testing it. Newer work with SWF will likely bring back at least some of what is being neglected in this PR (in the ci.yam;), so it is commented instead of deleted. At some later point we'll delete the MMR work. 