### PR TITLE
ci(release): remove unnecessary step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -200,9 +200,6 @@ jobs:
         with:
           ref: main
 
-      - name: Download artifacts
-        uses: dawidd6/action-download-artifact@v2
-
       - name: Draft release
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This step was only needed for the changelog automation which was removed in #297, and will fail if no artifacts are found (as is now the case)