### PR TITLE
change urls for when pydot fails

### DIFF
--- a/examples/01_multi-process_models.ipynb
+++ b/examples/01_multi-process_models.ipynb
@@ -298,13 +298,13 @@
     "        show_params=show_params,\n",
     "    ).SVG(verbose=True, dpi=48)\n",
     "except:\n",
-    "    static_url = \"https://private-user-images.githubusercontent.com/12465248/259783743-7813cba0-343c-4bf1-9b15-6ed92930f288.svg?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTg4MzcwMTQsIm5iZiI6MTcxODgzNjcxNCwicGF0aCI6Ii8xMjQ2NTI0OC8yNTk3ODM3NDMtNzgxM2NiYTAtMzQzYy00YmYxLTliMTUtNmVkOTI5MzBmMjg4LnN2Zz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA2MTklMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNjE5VDIyMzgzNFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTEzNWMxMTQ2MjE2YjM0NjI1ZDA4ZGI0Nzg1YTEyMTlkYjYxYWVhYmJjNTdkMTVjYzY0NzRkYjFkODU0ZGMxMTUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.MtkzgxHiDRsavGls_UNtKC54R0hyuXAs45u4SbvFO-c\"\n",
+    "    static_url = \"https://github.com/EC-USGS/pywatershed/releases/download/1.1.0/notebook_01_cell_11_model_graph.png\"\n",
     "    print(\n",
     "        f\"Dot fails on some machines. You can see the graph at this url: {static_url}\"\n",
     "    )\n",
     "    from IPython.display import Image\n",
     "\n",
-    "    display(Image(url=static_url))"
+    "    display(Image(url=static_url, width=1300))"
    ]
   },
   {
@@ -551,13 +551,13 @@
     "        show_params=show_params,\n",
     "    ).SVG(verbose=True, dpi=48)\n",
     "except:\n",
-    "    static_url = \"https://private-user-images.githubusercontent.com/12465248/259783743-7813cba0-343c-4bf1-9b15-6ed92930f288.svg?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTg4MzcwMTQsIm5iZiI6MTcxODgzNjcxNCwicGF0aCI6Ii8xMjQ2NTI0OC8yNTk3ODM3NDMtNzgxM2NiYTAtMzQzYy00YmYxLTliMTUtNmVkOTI5MzBmMjg4LnN2Zz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA2MTklMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNjE5VDIyMzgzNFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTEzNWMxMTQ2MjE2YjM0NjI1ZDA4ZGI0Nzg1YTEyMTlkYjYxYWVhYmJjNTdkMTVjYzY0NzRkYjFkODU0ZGMxMTUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.MtkzgxHiDRsavGls_UNtKC54R0hyuXAs45u4SbvFO-c\"\n",
+    "    static_url = \"https://github.com/EC-USGS/pywatershed/releases/download/1.1.0/notebook_01_cell_11_model_graph.png\"\n",
     "    print(\n",
     "        f\"Dot fails on some machines. You can see the graph at this url: {static_url}\"\n",
     "    )\n",
     "    from IPython.display import Image\n",
     "\n",
-    "    display(Image(url=static_url))"
+    "    display(Image(url=static_url, width=1300))"
    ]
   },
   {
@@ -1105,13 +1105,13 @@
     "        show_params=show_params,\n",
     "    ).SVG(verbose=True, dpi=48)\n",
     "except:\n",
-    "    static_url = \"https://private-user-images.githubusercontent.com/12465248/259783766-e0902e7f-ac69-488c-8719-858315d45e7c.svg?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTg4MzcwMTQsIm5iZiI6MTcxODgzNjcxNCwicGF0aCI6Ii8xMjQ2NTI0OC8yNTk3ODM3NjYtZTA5MDJlN2YtYWM2OS00ODhjLTg3MTktODU4MzE1ZDQ1ZTdjLnN2Zz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA2MTklMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNjE5VDIyMzgzNFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWFiMmVhNDg3MTNmYmFjNWE0NWQ3NDM0NTcyMTE4NWI0ZmMxMzQwOGQ4MjJjNjY5Y2NlM2U1YTcwN2VjYjRiYWYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.N9V5vcLla2MENY5CTma4gomxbBSh3YIfYX0X6zfbzRM\"\n",
+    "    static_url = \"https://github.com/EC-USGS/pywatershed/releases/download/1.1.0/notebook_01_cell_45_submodel_graph.png\"\n",
     "    print(\n",
     "        f\"Dot fails on some machines. You can see the graph at this url: {static_url}\"\n",
     "    )\n",
     "    from IPython.display import Image\n",
     "\n",
-    "    display(Image(url=static_url))"
+    "    display(Image(url=static_url, width=700))"
    ]
   },
   {

--- a/examples/02_prms_legacy_models.ipynb
+++ b/examples/02_prms_legacy_models.ipynb
@@ -22,22 +22,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7275fe95-8e0b-45f9-837c-ad6f7d38ced7",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# auto-format the code in this notebook\n",
-    "%load_ext jupyter_black"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "816e410d-c806-4467-8d56-e6add8c7f516",
    "metadata": {
     "editable": true,
@@ -57,13 +41,16 @@
     "import pydoc\n",
     "\n",
     "import hvplot.pandas  # noqa\n",
+    "import jupyter_black\n",
     "import numpy as np\n",
     "import pywatershed as pws\n",
     "import xarray as xr\n",
     "\n",
     "from helpers import gis_files\n",
     "\n",
-    "gis_files.download()  # this downloads GIS files"
+    "gis_files.download()  # this downloads GIS files\n",
+    "\n",
+    "jupyter_black.load()  # auto-format the code in this notebook"
    ]
   },
   {
@@ -364,13 +351,13 @@
     "        show_params=show_params,\n",
     "    ).SVG(verbose=True, dpi=48)\n",
     "except:\n",
-    "    static_url = \"https://private-user-images.githubusercontent.com/12465248/259783743-7813cba0-343c-4bf1-9b15-6ed92930f288.svg?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTg4MzcwMTQsIm5iZiI6MTcxODgzNjcxNCwicGF0aCI6Ii8xMjQ2NTI0OC8yNTk3ODM3NDMtNzgxM2NiYTAtMzQzYy00YmYxLTliMTUtNmVkOTI5MzBmMjg4LnN2Zz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA2MTklMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNjE5VDIyMzgzNFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTEzNWMxMTQ2MjE2YjM0NjI1ZDA4ZGI0Nzg1YTEyMTlkYjYxYWVhYmJjNTdkMTVjYzY0NzRkYjFkODU0ZGMxMTUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.MtkzgxHiDRsavGls_UNtKC54R0hyuXAs45u4SbvFO-c\"\n",
+    "    static_url = \"https://github.com/EC-USGS/pywatershed/releases/download/1.1.0/notebook_01_cell_11_model_graph.png\"\n",
     "    print(\n",
     "        f\"Dot fails on some machines. You can see the graph at this url: {static_url}\"\n",
     "    )\n",
     "    from IPython.display import Image\n",
     "\n",
-    "    display(Image(url=static_url))"
+    "    display(Image(url=static_url, width=1300))"
    ]
   },
   {
@@ -498,13 +485,13 @@
     "        show_params=show_params,\n",
     "    ).SVG(verbose=True, dpi=48)\n",
     "except:\n",
-    "    static_url = \"https://private-user-images.githubusercontent.com/12465248/259783766-e0902e7f-ac69-488c-8719-858315d45e7c.svg?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTg4MzcwMTQsIm5iZiI6MTcxODgzNjcxNCwicGF0aCI6Ii8xMjQ2NTI0OC8yNTk3ODM3NjYtZTA5MDJlN2YtYWM2OS00ODhjLTg3MTktODU4MzE1ZDQ1ZTdjLnN2Zz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA2MTklMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNjE5VDIyMzgzNFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWFiMmVhNDg3MTNmYmFjNWE0NWQ3NDM0NTcyMTE4NWI0ZmMxMzQwOGQ4MjJjNjY5Y2NlM2U1YTcwN2VjYjRiYWYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.N9V5vcLla2MENY5CTma4gomxbBSh3YIfYX0X6zfbzRM\"\n",
+    "    static_url = \"https://github.com/EC-USGS/pywatershed/releases/download/1.1.0/notebook_01_cell_45_submodel_graph.png\"\n",
     "    print(\n",
     "        f\"Dot fails on some machines. You can see the graph at this url: {static_url}\"\n",
     "    )\n",
     "    from IPython.display import Image\n",
     "\n",
-    "    display(Image(url=static_url))"
+    "    display(Image(url=static_url, width=700))"
    ]
   },
   {


### PR DESCRIPTION
Simply change URLs to be more clear/reliable for when pydot is broken on certain platforms/situations.